### PR TITLE
getRandomInteger generates integer which is not greater than min using Openssl generator

### DIFF
--- a/Tests/RandomTest.php
+++ b/Tests/RandomTest.php
@@ -94,17 +94,33 @@ class RandomTest extends TestCase
         $this->assertRegExp('/.{22}/', $random->getRandomString(21) . $random->getRandomString(1, '.Oeu'));
     }
 
-    public function testOpenSSLGeneratesInteger()
+    /**
+     * @dataProvider getDataForOpenSSLGeneratesIntegerTest
+     */
+    public function testOpenSSLGeneratesInteger($min, $max)
     {
         if (!OpenSSLGenerator::isSupported()) {
             $this->markTestSkipped('OpenSSL is not supported on this platform.');
         }
 
         $random = new Random(new OpenSSLGenerator());
-        $int = $random->getRandomInteger(10);
+        $int = $random->getRandomInteger(10, $max !== null ? $max : PHP_INT_MAX);
 
-        $this->assertTrue($int >= 10, 'The generated integer is greater than min');
+        $this->assertTrue($int >= 10, 'The generated integer ' . $int . ' is greater (or equal) ' . $min);
+
+        if ($max !== null) {
+            $this->assertTrue($int <= $max, 'The generated integer ' . $int . ' is smaller (or equal) to ' . $max);
+        }
     }
 
+    public function getDataForOpenSSLGeneratesIntegerTest()
+    {
+        return array(
+            array(10, null),
+            array(10, 150),
+            array(-10, 150),
+            array(-10, null),
+        );
+    }
 }
 

--- a/Tests/RandomTest.php
+++ b/Tests/RandomTest.php
@@ -103,7 +103,7 @@ class RandomTest extends TestCase
         $random = new Random(new OpenSSLGenerator());
         $int = $random->getRandomInteger(10);
 
-        $this->assertTrue($int >= 10);
+        $this->assertTrue($int >= 10, 'The generated integer is greater than min');
     }
 
 }

--- a/Tests/RandomTest.php
+++ b/Tests/RandomTest.php
@@ -10,6 +10,7 @@
 
 namespace Rych\Random\Tests;
 
+use Rych\Random\Generator\OpenSSLGenerator;
 use Rych\Random\Random;
 use PHPUnit_Framework_TestCase as TestCase;
 
@@ -91,6 +92,18 @@ class RandomTest extends TestCase
         $this->assertRegExp('/^[0-9]{10}$/', $random->getRandomString(10, '0123456789'));
         $this->assertRegExp('/^[qwerty]{10}$/', $random->getRandomString(10, 'qwerty'));
         $this->assertRegExp('/.{22}/', $random->getRandomString(21) . $random->getRandomString(1, '.Oeu'));
+    }
+
+    public function testOpenSSLGeneratesInteger()
+    {
+        if (!OpenSSLGenerator::isSupported()) {
+            $this->markTestSkipped('OpenSSL is not supported on this platform.');
+        }
+
+        $random = new Random(new OpenSSLGenerator());
+        $int = $random->getRandomInteger(10);
+
+        $this->assertTrue($int >= 10);
     }
 
 }


### PR DESCRIPTION
This bug appeared randomly in our CI (we have a wrapper around this library) when we tested the generated integers.

I used the code from ircmaxell/random-lib to patch the code.